### PR TITLE
Rules update

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,23 +3,48 @@
 <em>"Be excellent to each other"</em> is easier said than done, and means different things to different people.
 </p>
 <p>
-The following rules are a (non-exhaustive) list of behaviours that may lead to deletion of toots, silencing or suspension of accounts, at the descretion of the instance administrators.
+The following rules are a (non-exhaustive) list of behaviours that may lead to deletion of toots, silencing or suspension of accounts, at the descretion of the instance administrators, as described in our <a href="/terms">Terms</a>.
 </p>
 <p>
 Please report behaviour that bothers you. We will keep your report confidential.
 </p>
 <ul>
-<li>We do not tolerate harrassment, stalking, and doxxing.</li>
-<li>We do not tolerate racism, sexism, verbal abuse, discrimination against gender and sexual minorities, or the advocation of any of these.</li>
+<li>We do not tolerate discriminatory behaviour and content promoting or advocating the oppression of members of marginalised groups. These groups may be characterised by any of the following (though this list is naturally incomplete):
+  <ul>
+    <li>ethnicity</li>
+    <li>gender identity or expression</li>
+    <li>sexual identity or expression</li>
+    <li>physical characteristics or age</li>
+    <li>disability or illness</li>
+    <li>nationality, residency, citizen status</li>
+    <li>wealth or education</li>
+    <li>faith, or lack thereof</li>
+  </ul>
+</li>
+<li>We do not tolerate threatening behaviour, stalking, and doxxing.</li>
+<li>We do not tolerate harassment, including brigading, dogpiling, or any other form of contact with a user who has stated that they do not wish to be contacted.</li>
+<li>We do not tolerate mobbing, including name-calling, intentional misgendering or deadnaming.</li>
 <li>We do not tolerate violent nationalist propaganda, Nazi symbolism or promoting the ideology of National Socialism.</li>
-<li>Do not contact people who made clear they want no contact. This includes dogpiling/brigading.</li>
-<li>Posts with sexual content or gore have to be tagged.</li>
-<li>Advertisements have to be tagged, and must not be excessive or automated.</li>
-<li>Automated posts should be <strong>unlisted</strong> (rendering visible to everybody, but not appearing on the local timeline) to keep the local timeline of our instance a place of community dialogue and human interaction. This extends to bots, feed posters, Twitter "retweets" and Twitter crossposts with broken mentions.</li>
-<li>Bots may only interact with a user when they're invited by that user to do so.</li>
-<li>If you need to post with a high frequency, please set your posts to be <strong>unlisted</strong> to keep the local timeline readable.</li>
-<li>In discussions, please remain civil, do not insult the people you're talking to, and try to avoid irony, sarcasm, or similar modes of language – they typically don't translate well to written language and tend to escalate discussions or misunderstandings.</li>
+<li>Actions intended to damage this instance or its performance may lead to immediate account suspension.</li>
+<li>Content that is illegal in Germany will be deleted and may lead to immediate account suspension.</li>
 </ul>
+<br>
+<h2 id="best-practices">Best practices <a href="#best-practices">¶</a></h2>
+
+<p>The list below is a collection of behaviour that we expect to see from our users. If you see a user go against these best practices in a way that bothers you, please file a report and we will talk to them. While these best practices are designed to be guidelines for a good communal instance, <strong>repeated malicious unwillingness</strong> to follow the best practices will be considered just like breaking a rule.</p>
+
+<ul>
+  <li>In general, use the tools provided to foster a considerate and accessible atmosphere. This includes the liberal use of content warnings (especially on potentially disturbing or controversial topics), and alt-text captioning of media files.</li>
+  <li>When possible, provide credit for creative works in your posts that are not your own.</li>
+  <li>Uninvited comments about another user's personal choices, lifestyle or family are strongly discouraged and may be considered harassment. Inappropriate sexual attention, comments about appearance and implication of physical contact will not be tolerated toward any non-consenting user.</li>
+  <li>Posts with sexual content or gore should be tagged.</li>
+  <li>Advertisements have to be tagged, and must not be excessive or automated.</li>
+  <li>Bots may only interact with a user when they're invited by that user to do so.</li>
+  <li>Automated posts and high-frequency posts should be <strong>unlisted</strong> (rendering visible to everybody, but not appearing on the local timeline) to keep the local timeline of our instance a place of community dialogue and human interaction. This extends to bots, feed posters, Twitter "retweets" and Twitter crossposts with broken mentions. Crossposter accounts that stop being active participants in our community may be removed at the discretion of the moderators.</li>
+  <li>In discussions, please remain civil, do not insult the people you're talking to, and try to avoid irony, sarcasm, or similar modes of language – they typically don't translate well to written language and tend to escalate discussions or misunderstandings.</li>
+</ul>
+
+<em>(These best practices were inspired by the Terms of bsd.network. Thank you!)</em>
 <br>
 <h2 id="resources">Resources <a href="#resources">¶</a></h2>
 <p>

--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@ Please report behaviour that bothers you. We will keep your report confidential.
     <li>disability or illness</li>
     <li>nationality, residency, citizen status</li>
     <li>wealth or education</li>
-    <li>religious affiliation, or lack thereof</li>
+    <li>religious affiliation, agnosticism or atheism</li>
   </ul>
 </li>
 <li>We do not tolerate threatening behaviour, stalking, and <a href="https://en.wikipedia.org/wiki/Doxxing">doxxing</a>.</li>

--- a/about.html
+++ b/about.html
@@ -18,10 +18,10 @@ Please report behaviour that bothers you. We will keep your report confidential.
     <li>disability or illness</li>
     <li>nationality, residency, citizen status</li>
     <li>wealth or education</li>
-    <li>faith, or lack thereof</li>
+    <li>religious affiliation, or lack thereof</li>
   </ul>
 </li>
-<li>We do not tolerate threatening behaviour, stalking, and doxxing.</li>
+<li>We do not tolerate threatening behaviour, stalking, and <a href="https://en.wikipedia.org/wiki/Doxxing">doxxing</a>.</li>
 <li>We do not tolerate harassment, including brigading, dogpiling, or any other form of contact with a user who has stated that they do not wish to be contacted.</li>
 <li>We do not tolerate mobbing, including name-calling, intentional misgendering or deadnaming.</li>
 <li>We do not tolerate violent nationalist propaganda, Nazi symbolism or promoting the ideology of National Socialism.</li>
@@ -37,11 +37,11 @@ Please report behaviour that bothers you. We will keep your report confidential.
   <li>In general, use the tools provided to foster a considerate and accessible atmosphere. This includes the liberal use of content warnings (especially on potentially disturbing or controversial topics), and alt-text captioning of media files.</li>
   <li>When possible, provide credit for creative works in your posts that are not your own.</li>
   <li>Uninvited comments about another user's personal choices, lifestyle or family are strongly discouraged and may be considered harassment. Inappropriate sexual attention, comments about appearance and implication of physical contact will not be tolerated toward any non-consenting user.</li>
-  <li>Posts with sexual content or gore should be tagged.</li>
-  <li>Advertisements have to be tagged, and must not be excessive or automated.</li>
+  <li>If you post sexual content or gore, use content warnings.</li>
+  <li>If you post advertisements, use a content warning. Advertisements should not be excessive or automated.</li>
   <li>Bots may only interact with a user when they're invited by that user to do so.</li>
   <li>Automated posts and high-frequency posts should be <strong>unlisted</strong> (rendering visible to everybody, but not appearing on the local timeline) to keep the local timeline of our instance a place of community dialogue and human interaction. This extends to bots, feed posters, Twitter "retweets" and Twitter crossposts with broken mentions. Crossposter accounts that stop being active participants in our community may be removed at the discretion of the moderators.</li>
-  <li>In discussions, please remain civil, do not insult the people you're talking to, and try to avoid irony, sarcasm, or similar modes of language – they typically don't translate well to written language and tend to escalate discussions or misunderstandings.</li>
+  <li>In discussions, please remain civil, do not insult the people you're talking to. Note that irony, sarcasm, or similar modes of language don't translate well to written language and tend to escalate discussions or misunderstandings.</li>
 </ul>
 
 <em>(These best practices were inspired by the Terms of bsd.network. Thank you!)</em>

--- a/terms.html
+++ b/terms.html
@@ -26,9 +26,9 @@ This page contains both our <a href="#terms">Terms of Service</a> (adapted from 
 
 <h3>Data Access</h3>
 
-<p>Content on this instance should not be used for the purposes of machine learning or other "research" purposes without the explicit consent of the users involved.</p>
+<p>Content on this instance must not be used for the purposes of machine learning or other "research" purposes without the explicit consent of the users involved.</p>
 
-<p>Content on this instance beyond this page should not be archived or indexed wholesale by automated means by any user or service. Active users may export their following lists and post content through the web interface.</p>
+<p>Content on this instance beyond this page must not be archived or indexed wholesale by automated means by any user or service. Active users may export their following lists and posts through the export provided on their settings page, or the API.</p>
 
 
 <hr class="spacer" />
@@ -43,7 +43,7 @@ This page contains both our <a href="#terms">Terms of Service</a> (adapted from 
   <li><em>Optional account information</em>: Display name, biography, profile information fields, profile picture, and header image. Display name, biography, profile picture and header image will always be public.</li>
   <li><em>Statuses and interactions</em>: We retain all your posts including attachments, and other interactions (such as favourites, follows and reblogs). In addition to the content and people involved, we also store the timestamps for all of the listed data entries. If these interactions impact another server (eg. following, boosting, or messaging a user on a different server), this other server will receive all required information. Public, unlisted, and pinned posts are available publicly. Follower-only posts are available to your followers, and direct messages are available to you and all people mentioned in the message. Please note that since we cannot control other servers, this means that we cannot guarantee the privacy status of your messages as soon as they leave our server.</li>
   <li><em>Cookies</em>: We use cookies to keep you logged in and save your preferences for future visits.</li>
-  <li><em>Other metadata</em>: We do not log or store your IP address. We retain the name of your browser application to allow you to review your currently logged in sessions for security reasons.</li>
+  <li><em>Other metadata</em>: We do not log or store your IP address as a rule. Exceptions will be made when we actively search for errors. Once we have finished the search for errors, collected IP addresses will be deleted. We retain the name of your browser application to allow you to review your currently logged in sessions for security reasons.</li>
 </ul>
 
 <hr class="spacer" />

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,86 @@
+This page contains both our <a href="#terms">Terms of Service</a> (adapted from the bsd.network ToS) and our <a href="#privacy">Privacy Policy</a>.
+
+<h2 id="terms">chaos.social Terms of Service</h2>
+
+<p>It is our intention that you use this service for personal enjoyment and respectful, friendly interaction. To that end, we hope to foster a welcoming and inclusive environment.</p>
+
+<p>The server is privately owned and open to users voluntarily, not a public space. Users wishing to join this community are expected to act without malice and in good faith. Doing otherwise may lead to removal from the service, independent of whether a user violates any rules outlined below.</p>
+
+<p>The administrators and moderators of this instance are <a href="https://chaos.social/@leah">@leah</a> and <a href="https://chaos.social/@rixx">@rixx</a>.</p>
+
+<p>The server hosting the instance is located in Germany.</p>
+
+<p>The following statements apply regardless of privacy level and instance of the users involved. In rare cases, public or private offline conduct or conduct on a separate instance may constitute grounds for removal from the service.</p>
+
+<hr class="spacer" />
+
+<h3>Policies and Rules</h3>
+
+<p>Our instance is subject to a set of rules governing user behaviour. The rules are always visible on our <a href="https://chaos.social/about/more">about page</a> and in our <a href="https://github.com/chaossocial/about/blob/master/about.html">public repository</a>.</p>
+
+<p>These rules are designed to maintain a friendly and open atmosphere, and to prevent harassment and discrimination. As such, they are a set of guidelines, but by necessity incomplete. Users violating the spirit of these rules will be treated no differently than users violating a specific rule.</p>
+
+<p>Please note that our rules contain a section on best practices, and users who repeatedly and despite warnings disregard these best practices may be seen to be in violation of our rules.</p>
+
+<p>The moderators may remove accounts who spam the instance, or are suspected of camping just to reserve an account name. Violation of the policies and rules may also lead to account removal at the discretion of the moderators.</p>
+
+<h3>Data Access</h3>
+
+<p>Content on this instance should not be used for the purposes of machine learning or other "research" purposes without the explicit consent of the users involved.</p>
+
+<p>Content on this instance beyond this page should not be archived or indexed wholesale by automated means by any user or service. Active users may export their following lists and post content through the web interface.</p>
+
+
+<hr class="spacer" />
+<hr class="spacer" />
+
+<h2 id="privacy">chaos.social Privacy Policy</h2>
+
+<h3 id="collect">Information collection</h3>
+
+<ul>
+  <li><em>Mandatory account information</em>: Username (always public), e-mail address, and password.</li>
+  <li><em>Optional account information</em>: Display name, biography, profile information fields, profile picture, and header image. Display name, biography, profile picture and header image will always be public.</li>
+  <li><em>Statuses and interactions</em>: We retain all your posts including attachments, and other interactions (such as favourites, follows and reblogs). In addition to the content and people involved, we also store the timestamps for all of the listed data entries. If these interactions impact another server (eg. following, boosting, or messaging a user on a different server), this other server will receive all required information. Public, unlisted, and pinned posts are available publicly. Follower-only posts are available to your followers, and direct messages are available to you and all people mentioned in the message. Please note that since we cannot control other servers, this means that we cannot guarantee the privacy status of your messages as soon as they leave our server.</li>
+  <li><em>Cookies</em>: We use cookies to keep you logged in and save your preferences for future visits.</li>
+  <li><em>Other metadata</em>: We do not log or store your IP address. We retain the name of your browser application to allow you to review your currently logged in sessions for security reasons.</li>
+</ul>
+
+<hr class="spacer" />
+
+<h3 id="use">Information usage</h3>
+
+<p>Any of the information we collect from you may be used in the following ways:</p>
+
+<ul>
+  <li>To provide the core functionality of Mastodon. You can only interact with other people's content and post your own content when you are logged in. For example, you may follow other people to view their combined posts in your own personalized home timeline.</li>
+  <li>To aid moderation of the community – when a status or account is reported, we will look into the matter as part of our moderation tasks.</li>
+  <li>The email address you provide may be used to send you information, notifications about other people interacting with your content or sending you messages, and to respond to inquiries, and/or other requests or questions.</li>
+</ul>
+
+<hr class="spacer" />
+
+<h3 id="protect">Information protection</h3>
+
+<p>We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information. Among other things, your browser session, as well as the traffic between your applications and the API, are secured with SSL, and your password is hashed using a strong one-way algorithm. You may enable two-factor authentication to further secure access to your account.</p>
+
+<hr class="spacer" />
+
+<h3 id="data-retention">Information deletion and retention</h3>
+
+<p>You can request and download an archive of your content, including your posts, media attachments, profile picture, and header image.</p>
+
+<p>You may irreversibly delete your account at any time.</p>
+
+<p>If we judge you to be breaking our instance rules, we may irreversibly delete your account at any time.</p>
+
+
+<hr class="spacer" />
+
+<h3 id="disclose">Information disclosure</h3>
+
+<p>Information is not disclosed unless you explicitly permit it. The only exception is the provider of our server, who is a trusted and unavoidable third party.</p>
+
+<p>Contacting or permitting contact from a user from a different instance implies your consent that the required data is shared with the server in question.</p>
+
+<p>Authorization of a third-party application grants information access depending on the scope of permissions you approve. The application may access your public profile information, your following list, your followers, your lists, all your posts, and your favourites. Applications can never access your e-mail address or password.</p>

--- a/terms.html
+++ b/terms.html
@@ -62,7 +62,7 @@ This page contains both our <a href="#terms">Terms of Service</a> (adapted from 
 
 <h3 id="protect">Information protection</h3>
 
-<p>We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information. Among other things, your browser session, as well as the traffic between your applications and the API, are secured with SSL, and your password is hashed using a strong one-way algorithm. You may enable two-factor authentication to further secure access to your account.</p>
+<p>We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information. Among other things, your browser session, as well as the traffic between your applications and the API, are secured with HTTPS, and your password is hashed using a strong one-way algorithm. You may enable two-factor authentication to further secure access to your account.</p>
 
 <hr class="spacer" />
 


### PR DESCRIPTION
This update does two things:

## Rules update

Our rules are good, but they mix hard rules and guidelines about user behaviour, which can be confusing to users, and makes it hard to give positive guidance.

I separated them into the rules, which include nearly everything from the old rules except for guidance on tagging and post visibility. I reworked the anti-discrimination clause to be more verbose and explicit. A whole bunch of phrases were taken from bsd.network – I'm currently communicating with them to get their approval of my blatant stealing.

The rules are now exclusively a list of forbidden behaviour, while the best practices model good behaviour. Repeated disregard of the best practices after warnings continues to be considered breaking the rules. I think having a section that explicitly states that we expect positive and accessible behaviour makes our rules more useful to the average user.

## Terms of Service

Up until now we used the default Mastodon Terms of Service, which are only a Privacy Policy, and contained a bunch of inaccuracies, such as claiming that we were logging IP addresses.

I have taken the Mastodon Privacy Policy, and deleted everything that was fluff or incorrect. Additionally I've stolen about half the Terms of bsd.network, which include a direct statement against sweeping data collection.