### PR TITLE
Add new rule for conspiracy narratives

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,6 +25,7 @@ Please report behaviour that bothers you. We will keep your report confidential.
 <li>We do not tolerate harassment, including brigading, dogpiling, or any other form of contact with a user who has stated that they do not wish to be contacted.</li>
 <li>We do not tolerate mobbing, including name-calling, intentional misgendering or deadnaming.</li>
 <li>We do not tolerate violent nationalist propaganda, Nazi symbolism or promoting the ideology of National Socialism.</li>
+<li>We do not tolerate conspiracy narratives or other reactionary myths supporting or leading to the above-mentioned (and/or similar) behavior.</li>
 <li>Actions intended to damage this instance or its performance may lead to immediate account suspension.</li>
 <li>Content that is illegal in Germany will be deleted and may lead to immediate account suspension.</li>
 </ul>


### PR DESCRIPTION
Conspiracy narratives are an emerging thread that could sometimes work around our existing rules. Make clear that they are not tolerated too.