### PR TITLE
Add アノニマスの見解 Pleroma instance to blocked_instances

### DIFF
--- a/blocked_instances.md
+++ b/blocked_instances.md
@@ -55,6 +55,7 @@ Blocked instances
 | pawoo.net                   | ⛔ | Untagged nfsw content, unwanted follow bots, lolicon\*\*\* |
 | paypig.org                  | ⛔ | Racism |
 | pieville.net                | ⛔ | Racism, antisemitism |
+| pl.anon-kenkai.com          | ⛔ | [Racism, antisemitism, lolicon, "free speech zone", discrimination](https://pl.anon-kenkai.com/notice/AGdCO1HBfYNH5jPPEG) |
 | play.xmr.101010.pl          | ⛔ | Cryptomining |
 | pleroma.rareome.ga          | ⛔ | Doesn't [respect blocks or status privacy](https://pleroma.rareome.ga/notice/113524), [lolicons](https://pleroma.rareome.ga/notice/55113)³ |
 | pleroma.nobodyhasthe.biz    | ⛔ | Doxxing and discrimination |


### PR DESCRIPTION
Included an entry for pl.anon-kenkai.com, which is an awful Pleroma instance populated by one of the worst human beings in existence. Please add it to your block list.